### PR TITLE
`fix:` remove `required` rule

### DIFF
--- a/codeigniter4-backend/app/Requests/Api/Rest/UpdateTaskRequest.php
+++ b/codeigniter4-backend/app/Requests/Api/Rest/UpdateTaskRequest.php
@@ -23,7 +23,7 @@ class UpdateTaskRequest extends FormRequest
             'description' => [],
             'due_date'    => ['required', 'valid_date'],
             'priority'    => ['required', 'integer', 'numeric', 'valid_priority'],
-            'is_finished' => ['required', 'boolean'],
+            'is_finished' => ['boolean'],
         ];
     }
 


### PR DESCRIPTION
`required` rule has been removed because it cause unexpected behaviour. For example, if user want to update the `is_finished` field with value of `false`, then it will be considered as an empty field so the `required` rule will be triggered.